### PR TITLE
Consolidate parameter workspace tabs and batch setup

### DIFF
--- a/docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md
+++ b/docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md
@@ -1,0 +1,124 @@
+---
+date: 2026-05-19
+topic: parameter-editor-scroll-and-maximize
+---
+
+# Parameter Editor Scroll and Maximize
+
+## Summary
+
+Improve the Parameters & Ranges editor so parameter editing feels like one coherent workspace: one vertical scroll path in the inline view, an inline Extend control for more page space, and a Maximize control for focused large-dialog editing.
+
+---
+
+## Problem Frame
+
+The current Parameters & Ranges area can contain nested fixed-height regions. In particular, the Cell Types table can scroll inside its own assigned area while the surrounding tab or parameter panel also scrolls. This creates a double-scroll experience that makes large parameter sets harder to scan, compare, and edit.
+
+The same area is also dense enough that users sometimes need more working room than the default sidebar-style panel provides. A clearer size model would let users choose between a compact inline editor, an expanded inline editor, and a large focused modal without changing the underlying configuration workflow.
+
+---
+
+## Actors
+
+- A1. Simulation user: Edits model parameters, cell types, parameter ranges, and batch sampling configuration.
+- A2. Implementer: Plans and builds the UI changes while preserving existing parameter editing behavior.
+
+---
+
+## Key Flows
+
+- F1. Inline parameter editing
+  - **Trigger:** A simulation user opens the Parameters & Ranges panel.
+  - **Actors:** A1
+  - **Steps:** The user chooses a parameter tab, scrolls through content, edits values, and moves between parameter groups without encountering nested vertical scrollbars inside the editor body.
+  - **Outcome:** The inline editor remains compact enough for normal use while providing one predictable scroll path.
+  - **Covered by:** R1, R2, R3, R6
+
+- F2. Extend inline workspace
+  - **Trigger:** A simulation user wants more room but does not want to leave the page context.
+  - **Actors:** A1
+  - **Steps:** The user clicks Extend, the inline Parameters & Ranges editor grows vertically, and the user continues editing with the same live configuration.
+  - **Outcome:** The page offers more editing space without opening a modal or creating a second draft state.
+  - **Covered by:** R4, R6, R8
+
+- F3. Maximize focused workspace
+  - **Trigger:** A simulation user needs a larger focused view for parameters or ranges.
+  - **Actors:** A1
+  - **Steps:** The user clicks Maximize, edits the same Parameters & Ranges experience in a large modal dialog, then closes the modal and returns to the page.
+  - **Outcome:** The modal provides more room while preserving edits and keeping behavior consistent with the inline editor.
+  - **Covered by:** R5, R6, R7, R8
+
+---
+
+## Requirements
+
+**Scroll Model**
+- R1. The inline Parameters & Ranges editor must expose only one vertical scrollbar for the main parameter-editing area.
+- R2. Parameter tabs and dense parameter sections, including Cell Types, must not introduce their own nested vertical scroll regions inside the main parameter editor.
+- R3. Horizontal overflow for wide content, such as multi-column cell type tables, may remain available when needed, but it must not create a second vertical scrolling experience.
+
+**Sizing Controls**
+- R4. The inline editor must provide an Extend control below the parameter area that grows the editor vertically on the page.
+- R5. The Parameters & Ranges view must provide a Maximize control that opens a large modal dialog for focused editing.
+- R6. Extend and Maximize must be distinct behaviors: Extend grows the inline editor, while Maximize opens the large modal.
+
+**Editing Behavior**
+- R7. The maximized modal must edit the same live configuration as the inline view, not a detached draft that requires a separate apply step.
+- R8. Values edited in inline, extended, or maximized mode must remain consistent when switching between those modes.
+
+**Visual Consistency**
+- R9. Layout, card, and tab changes are in scope when they directly support a clearer Parameters & Ranges editing experience.
+- R10. The result should preserve the existing functional surface of loading, saving, sharing, presets, parameter editing, ranges, and batch sampling.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2.** Given the user opens Cell Types inside Parameters & Ranges, when the table content exceeds the visible height, the user scrolls the main editor area rather than a nested vertical table container.
+- AE2. **Covers R3.** Given the Cell Types table is wider than the available panel, when the user needs hidden columns, horizontal scrolling remains available without adding an inner vertical scrollbar.
+- AE3. **Covers R4, R6.** Given the inline editor is in its default size, when the user clicks Extend, the parameter area grows inline and no modal opens.
+- AE4. **Covers R5, R7, R8.** Given the user changes a parameter in the maximized modal, when the user closes the modal, the inline view reflects the same changed value.
+
+---
+
+## Success Criteria
+
+- Users can edit large parameter sections without fighting double vertical scrollbars.
+- The size controls are understandable from behavior alone: Extend means more inline room, Maximize means focused modal.
+- Planning can proceed without inventing the intended scroll model, sizing behavior, or live-editing semantics.
+
+---
+
+## Scope Boundaries
+
+- Broad redesign of the whole application shell is out of scope.
+- Changes to app cards, spacing, tab layout, or panel structure are allowed when they directly improve the Parameters & Ranges experience.
+- Changes to parameter schemas, simulation semantics, batch range generation, or TOML import/export behavior are out of scope.
+- Modal editing should reuse the same conceptual editor experience rather than introducing a separate wizard or alternate parameter editor.
+
+---
+
+## Key Decisions
+
+- Extend is inline: It gives users more room without changing context.
+- Maximize is modal: It supports focused editing when the inline panel is too constrained.
+- Modal edits are live: This avoids an extra apply/cancel model and keeps all editor modes consistent.
+- Scroll consistency takes priority over preserving current fixed-height inner panels.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing parameter editing, range editing, preset, and file-operation behavior remains the source of truth.
+- The modal can share the same configuration state as the inline editor.
+- Some horizontal scrolling may still be necessary for wide parameter tables.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R4][Technical] What exact expanded height should Extend use, and should it be reversible via the same control?
+- [Affects R5][Technical] What modal dimensions and responsive behavior best fit the existing UI system?

--- a/docs/brainstorms/2026-05-19-parameter-ranges-tab-requirements.md
+++ b/docs/brainstorms/2026-05-19-parameter-ranges-tab-requirements.md
@@ -1,0 +1,44 @@
+---
+date: 2026-05-19
+topic: parameter-ranges-tab
+---
+
+# Parameter Ranges Tab
+
+## Summary
+
+Move Parameter Ranges into the existing parameter editor tab row as a sibling of Parameters, Constants, Cell Types, Events, and Simulation. The ranges editor should feel like part of the same parameter workspace instead of a stacked section below the model parameter tabs.
+
+## Problem Frame
+
+The parameter editor currently mixes two navigation patterns: model settings use tabs, while Parameter Ranges sits as a separate section below them. That makes the panel feel longer and less coherent, especially after the maximize and scroll cleanup work made the tabbed workspace the primary interaction surface.
+
+## Requirements
+
+- R1. Parameter Ranges must appear as a tab in the existing model parameter tab row.
+- R2. Selecting the Parameter Ranges tab must show the existing range editor behavior: adding sweep parameters, editing min/max/steps, showing base values, and removing ranges.
+- R3. The existing model-specific tabs must remain available and keep their current labels and behavior.
+- R4. The file actions, preset selector, maximize behavior, and batch sampling controls must remain outside the model tab content.
+- R5. The tab layout must avoid introducing horizontal page overflow; any necessary overflow should stay inside the intended workspace.
+
+## Success Criteria
+
+- Users can switch between ordinary parameter editing and range setup using the same tab row.
+- The parameter panel no longer has a standalone Parameter Ranges section below the model parameter tabs.
+- A planner can implement the UI change without inventing new navigation structure or moving batch sampling.
+
+## Scope Boundaries
+
+- Batch Sampling remains outside the tab row.
+- Batch results, batch execution behavior, and range generation semantics are unchanged.
+- No new top-level card tabs are introduced.
+
+## Key Decisions
+
+- Parameter Ranges belongs in the model tab row: this keeps the parameter workspace stable while reducing stacked sections.
+- Batch Sampling stays separate: it is related to running batches, but the user only confirmed moving Parameter Ranges.
+
+## Dependencies / Assumptions
+
+- The existing Parameter Ranges editor behavior is correct and should be relocated, not redesigned.
+- The model parameter tab row is the right conceptual home for range setup because ranges are chosen from model parameters.

--- a/docs/brainstorms/2026-05-19-parameter-ranges-tab-requirements.md
+++ b/docs/brainstorms/2026-05-19-parameter-ranges-tab-requirements.md
@@ -1,44 +1,44 @@
 ---
 date: 2026-05-19
-topic: parameter-ranges-tab
+topic: batch-setup-tab
 ---
 
-# Parameter Ranges Tab
+# Batch Setup Tab
 
 ## Summary
 
-Move Parameter Ranges into the existing parameter editor tab row as a sibling of Parameters, Constants, Cell Types, Events, and Simulation. The ranges editor should feel like part of the same parameter workspace instead of a stacked section below the model parameter tabs.
+Move batch setup controls into the existing parameter editor tab row as a sibling of Parameters, Constants, Cell Types, Events, and Simulation. The tab should include Parameter Ranges and Batch Sampling so batch configuration feels like one workspace instead of stacked sections below the model parameter tabs.
 
 ## Problem Frame
 
-The parameter editor currently mixes two navigation patterns: model settings use tabs, while Parameter Ranges sits as a separate section below them. That makes the panel feel longer and less coherent, especially after the maximize and scroll cleanup work made the tabbed workspace the primary interaction surface.
+The parameter editor currently mixes two navigation patterns: model settings use tabs, while batch setup controls sit as separate sections below them. That makes the panel feel longer and less coherent, especially after the maximize and scroll cleanup work made the tabbed workspace the primary interaction surface.
 
 ## Requirements
 
-- R1. Parameter Ranges must appear as a tab in the existing model parameter tab row.
-- R2. Selecting the Parameter Ranges tab must show the existing range editor behavior: adding sweep parameters, editing min/max/steps, showing base values, and removing ranges.
+- R1. Batch setup must appear as a tab in the existing model parameter tab row.
+- R2. Selecting the Batch Setup tab must show the existing range editor behavior: adding sweep parameters, editing min/max/steps, showing base values, and removing ranges.
 - R3. The existing model-specific tabs must remain available and keep their current labels and behavior.
-- R4. The file actions, preset selector, maximize behavior, and batch sampling controls must remain outside the model tab content.
-- R5. The tab layout must avoid introducing horizontal page overflow; any necessary overflow should stay inside the intended workspace.
+- R4. Selecting the Batch Setup tab must show the existing batch sampling controls, including time samples and seeds per configuration.
+- R5. The file actions, preset selector, and maximize behavior must remain outside the model tab content.
+- R6. The tab layout must avoid introducing horizontal page overflow; any necessary overflow should stay inside the intended workspace.
 
 ## Success Criteria
 
-- Users can switch between ordinary parameter editing and range setup using the same tab row.
-- The parameter panel no longer has a standalone Parameter Ranges section below the model parameter tabs.
-- A planner can implement the UI change without inventing new navigation structure or moving batch sampling.
+- Users can switch between ordinary parameter editing and batch setup using the same tab row.
+- The parameter panel no longer has standalone Parameter Ranges or Batch Sampling sections below the model parameter tabs.
+- A planner can implement the UI change without inventing new top-level navigation structure.
 
 ## Scope Boundaries
 
-- Batch Sampling remains outside the tab row.
 - Batch results, batch execution behavior, and range generation semantics are unchanged.
 - No new top-level card tabs are introduced.
 
 ## Key Decisions
 
-- Parameter Ranges belongs in the model tab row: this keeps the parameter workspace stable while reducing stacked sections.
-- Batch Sampling stays separate: it is related to running batches, but the user only confirmed moving Parameter Ranges.
+- Batch setup belongs in the model tab row: this keeps the parameter workspace stable while reducing stacked sections.
+- Parameter Ranges and Batch Sampling belong together: both configure how batch runs are generated from the current parameters.
 
 ## Dependencies / Assumptions
 
-- The existing Parameter Ranges editor behavior is correct and should be relocated, not redesigned.
-- The model parameter tab row is the right conceptual home for range setup because ranges are chosen from model parameters.
+- The existing Parameter Ranges and Batch Sampling behavior is correct and should be relocated, not redesigned.
+- The model parameter tab row is the right conceptual home for batch setup because ranges and samples are derived from the current model parameters.

--- a/docs/plans/2026-05-19-001-feat-parameter-editor-workspace-plan.md
+++ b/docs/plans/2026-05-19-001-feat-parameter-editor-workspace-plan.md
@@ -1,0 +1,306 @@
+---
+title: "feat: Improve parameter editor workspace"
+type: feat
+status: completed
+date: 2026-05-19
+origin: docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md
+---
+
+# feat: Improve parameter editor workspace
+
+## Summary
+
+Refactor the Parameters & Ranges editor into a reusable workspace that can render compact inline, extended inline, and maximized modal presentations while sharing one live configuration state. The plan removes nested vertical scrolling from the parameter tabs, preserves horizontal overflow for wide tables, and adds focused UI coverage for the new sizing behavior.
+
+---
+
+## Problem Frame
+
+The current editor constrains the model parameter panel inside fixed-height containers, and dense sections such as Cell Types add their own scrolling. Users can end up managing more than one vertical scrollbar while editing related parameter content (see origin: docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md).
+
+---
+
+## Requirements
+
+- R1. The inline Parameters & Ranges editor exposes one main vertical scroll path for parameter editing.
+- R2. Parameter tabs and dense sections, including Cell Types, do not add nested vertical scroll regions inside that main editor.
+- R3. Wide content may keep horizontal overflow when needed without adding an inner vertical scrollbar.
+- R4. The inline editor provides an Extend control that grows the editor vertically on the page.
+- R5. The Parameters & Ranges view provides a Maximize control that opens a large modal dialog.
+- R6. Extend and Maximize remain distinct behaviors: Extend is inline; Maximize is modal.
+- R7. The maximized modal edits the same live configuration as the inline view.
+- R8. Values stay consistent when switching between compact, extended, and maximized modes.
+- R9. Layout, card, tab, and spacing changes are allowed when they directly improve the Parameters & Ranges experience.
+- R10. Existing load, save, share, preset, parameter editing, ranges, and batch sampling behavior is preserved.
+
+**Origin actors:** A1 (simulation user), A2 (implementer)
+**Origin flows:** F1 (inline parameter editing), F2 (extend inline workspace), F3 (maximize focused workspace)
+**Origin acceptance examples:** AE1 (single vertical scroll for Cell Types), AE2 (horizontal overflow for wide Cell Types), AE3 (Extend grows inline), AE4 (modal edits live configuration)
+
+---
+
+## Scope Boundaries
+
+- Broad redesign of the whole application shell remains out of scope.
+- Layout, card, tab, and spacing cleanup is in scope only when it directly supports the parameter editor workspace.
+- Parameter schemas, simulation semantics, batch range generation, and TOML import/export behavior remain unchanged.
+- The maximized modal reuses the same editor experience rather than introducing a wizard, staged draft, or alternate parameter editing flow.
+- The plan adds the smallest practical DOM test setup for this feature; broader frontend test infrastructure cleanup is deferred.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/components/params/ParameterConfigView.tsx` currently owns the Parameters & Ranges card, file actions, preset selector, fixed-height `ModelParameterPanel`, `ParameterRangeList`, and batch sampling controls.
+- `src/components/params/ModelParameterPanel.tsx` currently wraps several tab bodies in `ScrollArea` and uses `overflow-auto` on Cell Types and Events tab content.
+- `src/models/eht/ui/CellTypesTab.tsx` currently adds `overflow-x-auto overflow-y-auto max-h-[600px]` around the table, causing the nested vertical scroll behavior called out in the origin document.
+- `src/components/batch/ParameterRangeList.tsx` already renders without an internal scroll container and should remain part of the unified editor flow.
+- `src/components/params/FormulaEditorDialog.tsx` provides the best local large-dialog pattern: Radix `Dialog`, `DialogContent` sized with viewport constraints, a header/action area, and a single scrollable body.
+- `src/components/ui/dialog.tsx`, `src/components/ui/button.tsx`, `src/components/ui/card.tsx`, and `src/components/ui/tabs.tsx` provide existing shadcn/Radix-style primitives.
+- `src/App.tsx` places `ParameterConfigView` in the right column of the main grid, so inline extension should work within that grid rather than changing app routing.
+
+### Institutional Learnings
+
+- No `docs/solutions/` learnings were present during planning.
+
+### External References
+
+- External research was not needed. This change follows existing React, Tailwind, Radix Dialog, and local component patterns already present in the repository.
+
+---
+
+## Key Technical Decisions
+
+- Shared editor body: Extract the repeated editor body from `ParameterConfigView` so compact, extended, and maximized presentations render the same controls against the same props and state.
+- Single vertical owner: Make the parameter workspace body the vertical scroll owner; remove nested vertical scroll from model tabs and Cell Types while retaining horizontal overflow where content is wider than the panel.
+- Reversible Extend: Treat Extend as a toggle so users can return to the compact inline editor without reloading the page or closing a modal.
+- Live modal edits: Open the maximized dialog against the same `config` and `onConfigChange` path, avoiding an Apply/Cancel draft model.
+- Minimal UI test harness: Add focused DOM component tests for this feature rather than broad frontend testing infrastructure.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Exact expanded height for Extend: Use a larger viewport-aware inline height that is reversible via the same control. The implementer may tune the final class values during visual verification.
+- Modal dimensions and responsiveness: Follow the large-dialog pattern used by the formula editor, with near-full viewport width, high viewport max-height, a fixed header, and one scrollable body.
+
+### Deferred to Implementation
+
+- Final Tailwind height classes: Choose the exact compact and expanded height constraints after checking desktop and mobile rendering.
+- Whether the Events tab needs any additional local layout adjustment after removing nested scroll wrappers: decide while visually verifying affected tabs.
+
+---
+
+## Implementation Units
+
+### U1. Add a Shared Parameter Workspace Body
+
+**Goal:** Separate the Parameters & Ranges editor contents from the card shell so the same body can render inline and inside a modal.
+
+**Requirements:** R5, R7, R8, R10; supports F3 and AE4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/components/params/ParameterConfigView.tsx`
+- Test: `src/components/params/ParameterConfigView.test.tsx`
+
+**Approach:**
+- Extract the file toolbar, preset selector, model parameter panel, range list, and batch sampling controls into an internal reusable body component or equivalent local composition.
+- Keep file input refs, import state, link-copy state, and all change handlers owned by `ParameterConfigView` so behavior remains unchanged.
+- Pass sizing or presentation flags into the body only for layout concerns; do not introduce separate config state for modal editing.
+
+**Patterns to follow:**
+- Keep the existing `ParameterConfigView` data flow: `handleParamsChange`, `handleRangesChange`, `handleTimeSamplesChange`, and `handleSeedsChange` continue to call `onConfigChange`.
+- Mirror the compact toolbar style already used in the current component.
+
+**Test scenarios:**
+- Happy path: render the editor body with default config, change a general parameter value, and assert `onConfigChange` receives updated `params` while preserving batch configuration.
+- Happy path: add or update a parameter range through the shared body and assert `onConfigChange` receives updated `parameterRanges`.
+- Integration: render inline and modal presentations from the same `config`; a value changed in one presentation is reflected when the component re-renders with the updated config.
+
+**Verification:**
+- Existing load, save, share, preset, parameter editing, ranges, and batch sampling controls remain visible and wired through the same callback path.
+
+---
+
+### U2. Normalize the Inline Scroll Model
+
+**Goal:** Remove nested vertical scrolling from parameter tabs and dense sections so the inline editor has one vertical scroll path.
+
+**Requirements:** R1, R2, R3, R9; supports F1, AE1, and AE2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/components/params/ParameterConfigView.tsx`
+- Modify: `src/components/params/ModelParameterPanel.tsx`
+- Modify: `src/models/eht/ui/CellTypesTab.tsx`
+- Test: `src/components/params/ParameterConfigView.test.tsx`
+
+**Approach:**
+- Make the inline parameter workspace body responsible for vertical overflow.
+- Remove `ScrollArea` wrappers and vertical `overflow-auto` behavior from `ModelParameterPanel` tab contents so tab panels expand naturally inside the workspace body.
+- Remove the vertical max-height wrapper from `EHTCellTypesTab` while preserving horizontal overflow for the table.
+- Keep tab headers sticky only if implementation proves it is necessary for usability; the primary requirement is one vertical scroll owner.
+
+**Patterns to follow:**
+- Continue using existing Radix Tabs primitives from `src/components/ui/tabs.tsx`.
+- Preserve the Cell Types table structure and editing controls; this unit changes containment and overflow, not table semantics.
+
+**Test scenarios:**
+- Happy path: Cell Types content renders without an element that combines vertical overflow with a fixed max-height.
+- Covers AE1. Given Cell Types content exceeds the visible inline area, the main parameter workspace is the scrollable vertical container.
+- Covers AE2. Given Cell Types columns exceed the available width, the table still supports horizontal overflow without adding an inner vertical scrollbar.
+
+**Verification:**
+- Visual inspection shows only one vertical scrollbar within the inline Parameters & Ranges editor.
+- Horizontal scrolling remains available for wide Cell Types tables.
+
+---
+
+### U3. Add Reversible Inline Extend Control
+
+**Goal:** Add an Extend control below the parameter area that toggles the inline editor between compact and expanded heights.
+
+**Requirements:** R4, R6, R8, R9; supports F2 and AE3
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `src/components/params/ParameterConfigView.tsx`
+- Test: `src/components/params/ParameterConfigView.test.tsx`
+
+**Approach:**
+- Add local state for inline expansion in `ParameterConfigView`.
+- Place the Extend control below the parameter workspace area, not inside a nested scrollable table or tab region.
+- Use icon-plus-label button styling consistent with the existing compact toolbar. The control label should reflect the current state, such as Extend vs Collapse.
+- Keep extension as a layout-only state: it must not affect config serialization, model params, ranges, or batch sampling.
+
+**Patterns to follow:**
+- Use lucide icons already available in the project.
+- Follow current button sizing and variant conventions in `ParameterConfigView`.
+
+**Test scenarios:**
+- Covers AE3. Given compact inline mode, clicking Extend increases the inline editor container state and does not open the modal.
+- Happy path: clicking the expanded-state control returns the editor to compact mode.
+- Edge case: toggling Extend after editing a parameter does not reset or discard the edited value.
+
+**Verification:**
+- The inline editor grows on the page and remains within the application grid.
+- The control is reachable below the parameter area and its behavior is visually distinct from Maximize.
+
+---
+
+### U4. Add Maximized Modal Presentation
+
+**Goal:** Add a Maximize control that opens the same Parameters & Ranges editor experience in a large focused modal.
+
+**Requirements:** R5, R6, R7, R8, R10; supports F3 and AE4
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `src/components/params/ParameterConfigView.tsx`
+- Test: `src/components/params/ParameterConfigView.test.tsx`
+
+**Approach:**
+- Add local modal-open state in `ParameterConfigView`.
+- Render the shared editor body inside a Radix `Dialog` using the large-dialog layout pattern from the formula editor: constrained viewport width, high max-height, a non-scrolling header, and one scrollable body.
+- Put Maximize near the Parameters & Ranges title or editor controls where it is discoverable but separate from Extend.
+- Ensure modal closing does not discard edits because edits flow through the same live `onConfigChange` path.
+
+**Patterns to follow:**
+- Follow `src/components/params/FormulaEditorDialog.tsx` for large modal sizing and internal scroll layout.
+- Use dialog primitives from `src/components/ui/dialog.tsx`.
+
+**Test scenarios:**
+- Happy path: clicking Maximize opens a dialog containing the Parameters & Ranges editor.
+- Covers AE4. Given a parameter is changed while maximized, closing the modal and re-rendering inline shows the same changed value.
+- Edge case: opening the modal while inline mode is extended does not require a separate draft or reset inline extension state.
+- Integration: modal content preserves range and batch sampling controls, not only model parameters.
+
+**Verification:**
+- The modal provides more usable editing space than compact inline mode.
+- The modal has one vertical scrollable body and no nested vertical scrollbars inside parameter tabs.
+
+---
+
+### U5. Add Focused UI Test Support
+
+**Goal:** Add the smallest practical DOM test setup needed to protect the parameter workspace behavior.
+
+**Requirements:** R1, R4, R5, R7, R8, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `vitest.config.ts`
+- Create: `src/components/params/ParameterConfigView.test.tsx`
+
+**Approach:**
+- Add a DOM test environment dependency and React DOM testing utilities appropriate for Vitest.
+- Keep the default Vitest environment as `node` for existing scientific/core tests; use per-file DOM environment configuration or targeted test config only for UI component tests.
+- Build a small render helper that wraps `ParameterConfigView` in the model provider context and imports registered models as needed.
+- Prefer behavior assertions over CSS-class snapshots, but include targeted assertions for the scroll-owner contract where behavior cannot be observed otherwise in a DOM test.
+
+**Patterns to follow:**
+- Preserve the existing Vitest setup and avoid slowing the current node-based test suite unnecessarily.
+- Follow the repository's existing preference for focused, file-local tests.
+
+**Test scenarios:**
+- Happy path: `ParameterConfigView` renders with the default model config under the test provider.
+- Integration: changing shared editor fields triggers `onConfigChange` with the expected part of the simulation config updated.
+- Scroll contract: Cell Types no longer renders with a fixed-height vertical scroll container, while the workspace body owns vertical overflow.
+- Mode contract: Extend toggles inline sizing; Maximize opens a dialog; both modes keep edits live.
+
+**Verification:**
+- Existing non-DOM tests remain runnable under the node environment.
+- New UI tests run under the DOM environment and cover the feature's main regressions.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The change is contained to the parameter editor UI and model-specific parameter tab layout. Simulation engine, batch execution, TOML parsing, and CSV export are not part of the interaction path.
+- **Error propagation:** Existing import error handling and clipboard fallback behavior remain unchanged.
+- **State lifecycle risks:** Inline and modal views must share `config` state through the existing callback path; no secondary draft state should be introduced.
+- **API surface parity:** No public model, batch, CLI, or export interfaces change.
+- **Integration coverage:** Browser or manual visual verification is needed because DOM tests cannot fully prove scrollbar feel, viewport fit, or modal ergonomics.
+- **Unchanged invariants:** Loading/saving TOML, importing XLSX, share links, presets, model parameter editing, range editing, time samples, and seed count behavior remain functionally equivalent.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Removing nested scroll containers makes very long tabs feel too tall in compact mode | Keep the workspace body height-constrained and make it the single scroll owner |
+| Horizontal Cell Types overflow regresses while fixing vertical scroll | Preserve horizontal overflow on a wrapper that does not own vertical scrolling |
+| Modal and inline views drift because they render separate editor implementations | Extract a shared body and pass the same config/change handlers into both presentations |
+| Adding DOM tests slows or destabilizes the existing node test suite | Keep node as the default Vitest environment and scope DOM setup to UI tests |
+| Exact height choices feel awkward on mobile or wide desktop | Treat height classes as implementation-time tuning and verify visually at representative viewport sizes |
+
+---
+
+## Documentation / Operational Notes
+
+- No user-facing documentation updates are required unless implementation changes visible labels beyond Extend, Collapse, or Maximize.
+- Before handoff, verify the UI in a browser at desktop and narrow viewports, including Cell Types, Parameters, Ranges, Extend, and Maximize.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md](../brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md)
+- Related code: `src/components/params/ParameterConfigView.tsx`
+- Related code: `src/components/params/ModelParameterPanel.tsx`
+- Related code: `src/models/eht/ui/CellTypesTab.tsx`
+- Related code: `src/components/batch/ParameterRangeList.tsx`
+- Related code: `src/components/params/FormulaEditorDialog.tsx`

--- a/docs/solutions/design-patterns/single-scroll-parameter-workspace-2026-05-19.md
+++ b/docs/solutions/design-patterns/single-scroll-parameter-workspace-2026-05-19.md
@@ -1,0 +1,96 @@
+---
+title: Single Scroll Owner for Dense Parameter Workspaces
+date: 2026-05-19
+category: design-patterns
+module: Parameters & Ranges UI
+problem_type: design_pattern
+component: tooling
+severity: medium
+applies_when:
+  - Building dense React editors with nested tabs, tables, or modal variants
+  - Reusing the same form controls across inline and maximized presentations
+  - Fixing double-scroll behavior in parameter-heavy UI panels
+tags: [react, ui-layout, scroll-ownership, modal-editing, parameter-editor]
+---
+
+# Single Scroll Owner for Dense Parameter Workspaces
+
+## Context
+
+The Parameters & Ranges panel had multiple competing vertical scroll regions. The overall parameter area had a fixed-height container, `ModelParameterPanel` wrapped some tab bodies in `ScrollArea` or `overflow-auto`, and the EHT Cell Types table added its own `max-h` plus vertical overflow. In practice, users could end up scrolling inside the Cell Types assignment area and then scrolling the surrounding parameter tab as a separate region.
+
+The same editor also needed two size modes: an inline expansion for staying in page context and a maximized modal for focused editing. The risk was duplicating the editor or creating a draft/apply model that would drift from the inline state.
+
+## Guidance
+
+For dense editor panels, choose one component as the vertical scroll owner and make nested sections expand naturally inside it. Keep horizontal overflow local only for genuinely wide content.
+
+In this app, the useful shape was:
+
+- `ParameterConfigView` owns the vertical scroll container for the Parameters & Ranges workspace.
+- `ModelParameterPanel` renders tabs and tab bodies without additional vertical `ScrollArea` wrappers.
+- `CellTypesTab` keeps `overflow-x-auto` for wide tables but removes its vertical `overflow-y-auto max-h[...]` wrapper.
+- Inline compact mode, inline extended mode, and modal mode all render the same shared editor body against the same `config` and `onConfigChange` path.
+- The maximized dialog mounts the editor body while the inline body is temporarily unmounted, avoiding duplicate input IDs and shared file-input refs behind the overlay.
+
+The important distinction is layout state versus data state:
+
+```tsx
+// Directional sketch, not exact production code
+const body = <ParameterConfigBody config={config} onConfigChange={onConfigChange} />;
+
+return (
+  <>
+    <div className="overflow-y-auto">
+      {!isMaximized && body}
+    </div>
+
+    <Dialog open={isMaximized} onOpenChange={setIsMaximized}>
+      <DialogContent>
+        <div className="overflow-y-auto">{body}</div>
+      </DialogContent>
+    </Dialog>
+  </>
+);
+```
+
+Extend/Collapse should only alter inline height. Maximize should only alter presentation. Neither should serialize into simulation config or create a second copy of the editor state.
+
+## Why This Matters
+
+Double-scroll editors are hard to operate because users lose track of which area currently owns wheel or trackpad input. Tables are especially painful: a fixed-height table can hide controls while the surrounding tab also looks scrollable.
+
+Sharing one editor body also prevents state drift. If inline and modal views are separate implementations, future parameter controls must be added twice, tests need to cover two surfaces, and bugs can appear in only one presentation. A shared body with one live config path keeps layout variants cheap.
+
+The subtle accessibility and correctness detail is to avoid mounting two copies of the same form at once when the modal opens. Hidden background copies can duplicate `id` attributes, file input refs, and labels. Temporarily unmounting the inline body while the modal is open keeps the dialog as the only active editor surface.
+
+## When to Apply
+
+- A panel has nested tabs, tables, accordions, or grouped forms and more than one vertical scrollbar appears.
+- A large editor needs both inline and modal presentations.
+- The modal is meant to edit live state rather than stage a draft.
+- DOM tests need to protect layout behavior that browser users experience as scroll ownership.
+
+## Examples
+
+Before:
+
+- A parameter card constrained `ModelParameterPanel` with a fixed height.
+- Individual tabs added `ScrollArea` or `overflow-auto`.
+- Cell Types added another fixed-height vertical scroll wrapper.
+- A modal version would have required duplicating the editor or risking duplicate mounted controls.
+
+After:
+
+- The parameter workspace has one `overflow-y-auto` owner.
+- Model tabs and Cell Types expand inside that owner.
+- Cell Types still has horizontal overflow for wide columns.
+- Extend toggles inline height only.
+- Maximize opens a large dialog that reuses the same editor body and live change handlers.
+- Component tests assert that Extend does not open the modal, the modal contains the same controls, and Cell Types no longer owns vertical overflow.
+
+## Related
+
+- Requirements: `docs/brainstorms/2026-05-19-parameter-editor-scroll-and-maximize-requirements.md`
+- Plan: `docs/plans/2026-05-19-001-feat-parameter-editor-workspace-plan.md`
+- Implementation touchpoints: `src/components/params/ParameterConfigView.tsx`, `src/components/params/ModelParameterPanel.tsx`, `src/models/eht/ui/CellTypesTab.tsx`

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,8 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/file-saver": "^2.0.7",
         "@types/lodash-es": "^4.17.12",
         "@types/pako": "^2.0.4",
@@ -63,6 +65,7 @@
         "@types/seedrandom": "^3.0.8",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/coverage-v8": "^4.0.16",
+        "jsdom": "^29.1.1",
         "prompts": "^2.4.2",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
@@ -70,6 +73,64 @@
         "vite": "^7.3.0",
         "vitest": "^4.0.16"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -370,6 +431,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -812,6 +1026,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2658,6 +2890,90 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3165,6 +3481,31 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -3175,6 +3516,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -3224,6 +3575,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-search-bounds": {
@@ -3459,6 +3820,27 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3867,6 +4249,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3955,6 +4351,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/earcut": {
       "version": "3.0.2",
@@ -4411,6 +4815,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4454,6 +4871,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -4541,6 +4968,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -4654,6 +5088,83 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -5039,6 +5550,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5411,6 +5933,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -5994,6 +6523,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mp4-muxer": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
@@ -6182,6 +6721,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6210,6 +6773,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -6473,6 +7046,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -6589,6 +7176,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -6670,6 +7267,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6788,6 +7398,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -6818,6 +7441,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -6915,6 +7545,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -6982,6 +7658,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7412,6 +8098,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -7420,6 +8119,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webm-muxer": {
@@ -7431,6 +8140,31 @@
       "dependencies": {
         "@types/dom-webcodecs": "^0.1.4",
         "@types/wicg-file-system-access": "^2020.9.5"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -7488,6 +8222,23 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/file-saver": "^2.0.7",
     "@types/lodash-es": "^4.17.12",
     "@types/pako": "^2.0.4",
@@ -86,6 +88,7 @@
     "@types/seedrandom": "^3.0.8",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.16",
+    "jsdom": "^29.1.1",
     "prompts": "^2.4.2",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,14 +58,14 @@ function AppContent() {
 
   return (
     <AppLayout>
-      <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-4">
-        <section>
+      <div className="grid min-w-0 grid-cols-1 gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <section className="min-w-0">
           <SingleSimulationTab />
         </section>
-        <section>
+        <section className="min-w-0">
           <ParameterConfigView config={config} onConfigChange={handleConfigChange} />
         </section>
-        <section className="lg:col-span-2">
+        <section className="min-w-0 lg:col-span-2">
           <BatchTab config={config} onConfigChange={handleConfigChange} />
         </section>
       </div>

--- a/src/components/batch/ParameterRangeList.tsx
+++ b/src/components/batch/ParameterRangeList.tsx
@@ -71,7 +71,7 @@ export function ParameterRangeList({ ranges, onChange, baseParams, disabled }: P
       <div className="flex items-center justify-between">
         <Label className="text-sm font-medium">Parameter Ranges</Label>
         <Select onValueChange={handleAdd} disabled={disabled || availableParams.length === 0}>
-          <SelectTrigger className="w-[200px] h-8">
+          <SelectTrigger className="w-[200px] h-8" aria-label="Add parameter range">
             <Plus className="h-4 w-4 mr-1" />
             <SelectValue placeholder="Add parameter" />
           </SelectTrigger>

--- a/src/components/params/ModelParameterPanel.tsx
+++ b/src/components/params/ModelParameterPanel.tsx
@@ -5,9 +5,8 @@
  */
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useModel } from '@/contexts';
-import { ParameterRangeList } from '@/components/batch/ParameterRangeList';
-import type { ParameterRange } from '@/core/batch';
 import type { BaseSimulationParams } from '@/core/registry';
+import type { ReactNode } from 'react';
 
 export interface ParameterTabProps<P = any> {
   params: P;
@@ -18,16 +17,14 @@ export interface ParameterTabProps<P = any> {
 export interface ModelParameterPanelProps {
   params: BaseSimulationParams;
   onChange: (params: BaseSimulationParams) => void;
-  parameterRanges?: ParameterRange[];
-  onParameterRangesChange?: (ranges: ParameterRange[]) => void;
+  batchSetupContent?: ReactNode;
   disabled?: boolean;
 }
 
 export function ModelParameterPanel({
   params,
   onChange,
-  parameterRanges,
-  onParameterRangesChange,
+  batchSetupContent,
   disabled,
 }: ModelParameterPanelProps) {
   const { currentModel } = useModel();
@@ -45,7 +42,7 @@ export function ModelParameterPanel({
   const hasCellTypes = !!CellTypesTab;
   const hasCellEvents = !!CellEventsTab;
   const hasSimulation = !!SimulationTab;
-  const hasParameterRanges = !!parameterRanges && !!onParameterRangesChange;
+  const hasBatchSetup = !!batchSetupContent;
 
   return (
     <div className="flex flex-col">
@@ -63,7 +60,7 @@ export function ModelParameterPanel({
           {hasCellTypes && <TabsTrigger value="celltypes" className="text-xs">Cell Types</TabsTrigger>}
           {hasCellEvents && <TabsTrigger value="cellevents" className="text-xs">Events</TabsTrigger>}
           {hasSimulation && <TabsTrigger value="simulation" className="text-xs">Simulation</TabsTrigger>}
-          {hasParameterRanges && <TabsTrigger value="ranges" className="text-xs">Parameter Ranges</TabsTrigger>}
+          {hasBatchSetup && <TabsTrigger value="batch" className="text-xs">Batch Setup</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="parameters" className="mt-0">
@@ -110,16 +107,9 @@ export function ModelParameterPanel({
           </TabsContent>
         )}
 
-        {hasParameterRanges && (
-          <TabsContent value="ranges" className="mt-0">
-            <div className="p-4">
-              <ParameterRangeList
-                ranges={parameterRanges}
-                onChange={onParameterRangesChange}
-                baseParams={params}
-                disabled={disabled}
-              />
-            </div>
+        {hasBatchSetup && (
+          <TabsContent value="batch" className="mt-0">
+            <div className="p-4 space-y-4">{batchSetupContent}</div>
           </TabsContent>
         )}
       </Tabs>

--- a/src/components/params/ModelParameterPanel.tsx
+++ b/src/components/params/ModelParameterPanel.tsx
@@ -4,7 +4,6 @@
  * into which each model can render its own UI components.
  */
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { useModel } from '@/contexts';
 import type { BaseSimulationParams } from '@/core/registry';
 
@@ -38,7 +37,7 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
   const hasSimulation = !!SimulationTab;
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="flex flex-col">
       {/* Warning banner - always visible above tabs */}
       {WarningBanner && (
         <div className="shrink-0 p-2">
@@ -46,8 +45,8 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
         </div>
       )}
 
-      <Tabs defaultValue="parameters" className="flex-1 flex flex-col min-h-0">
-        <TabsList className="w-full justify-start shrink-0 h-9">
+      <Tabs defaultValue="parameters" className="flex flex-col">
+        <TabsList className="w-full justify-start shrink-0 h-9 overflow-x-auto">
           <TabsTrigger value="parameters" className="text-xs">Parameters</TabsTrigger>
           {hasConstants && <TabsTrigger value="constants" className="text-xs">Constants</TabsTrigger>}
           {hasCellTypes && <TabsTrigger value="celltypes" className="text-xs">Cell Types</TabsTrigger>}
@@ -55,32 +54,28 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
           {hasSimulation && <TabsTrigger value="simulation" className="text-xs">Simulation</TabsTrigger>}
         </TabsList>
 
-        <TabsContent value="parameters" className="flex-1 overflow-hidden mt-0">
-          <ScrollArea className="h-full">
-            <div className="p-4 space-y-3">
-              {ParametersTab ? (
-                <ParametersTab params={params} onChange={onChange} disabled={disabled} />
-              ) : (
-                <div className="text-sm text-muted-foreground">
-                  No parameter UI defined for this model.
-                </div>
-              )}
-            </div>
-          </ScrollArea>
+        <TabsContent value="parameters" className="mt-0">
+          <div className="p-4 space-y-3">
+            {ParametersTab ? (
+              <ParametersTab params={params} onChange={onChange} disabled={disabled} />
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                No parameter UI defined for this model.
+              </div>
+            )}
+          </div>
         </TabsContent>
 
         {hasConstants && (
-          <TabsContent value="constants" className="flex-1 overflow-hidden mt-0">
-            <ScrollArea className="h-full">
-              <div className="p-4 space-y-3">
-                <ConstantsTab params={params} onChange={onChange} disabled={disabled} />
-              </div>
-            </ScrollArea>
+          <TabsContent value="constants" className="mt-0">
+            <div className="p-4 space-y-3">
+              <ConstantsTab params={params} onChange={onChange} disabled={disabled} />
+            </div>
           </TabsContent>
         )}
 
         {hasCellTypes && (
-          <TabsContent value="celltypes" className="flex-1 mt-0 overflow-auto">
+          <TabsContent value="celltypes" className="mt-0">
             <div className="p-4">
               <CellTypesTab params={params} onChange={onChange} disabled={disabled} />
             </div>
@@ -88,7 +83,7 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
         )}
 
         {hasCellEvents && (
-          <TabsContent value="cellevents" className="flex-1 mt-0 overflow-auto">
+          <TabsContent value="cellevents" className="mt-0">
             <div className="p-4">
               <CellEventsTab params={params} onChange={onChange} disabled={disabled} />
             </div>
@@ -96,12 +91,10 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
         )}
 
         {hasSimulation && (
-          <TabsContent value="simulation" className="flex-1 overflow-hidden mt-0">
-            <ScrollArea className="h-full">
-              <div className="p-4 space-y-3">
-                <SimulationTab params={params} onChange={onChange} disabled={disabled} />
-              </div>
-            </ScrollArea>
+          <TabsContent value="simulation" className="mt-0">
+            <div className="p-4 space-y-3">
+              <SimulationTab params={params} onChange={onChange} disabled={disabled} />
+            </div>
           </TabsContent>
         )}
       </Tabs>

--- a/src/components/params/ModelParameterPanel.tsx
+++ b/src/components/params/ModelParameterPanel.tsx
@@ -5,6 +5,8 @@
  */
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useModel } from '@/contexts';
+import { ParameterRangeList } from '@/components/batch/ParameterRangeList';
+import type { ParameterRange } from '@/core/batch';
 import type { BaseSimulationParams } from '@/core/registry';
 
 export interface ParameterTabProps<P = any> {
@@ -16,10 +18,18 @@ export interface ParameterTabProps<P = any> {
 export interface ModelParameterPanelProps {
   params: BaseSimulationParams;
   onChange: (params: BaseSimulationParams) => void;
+  parameterRanges?: ParameterRange[];
+  onParameterRangesChange?: (ranges: ParameterRange[]) => void;
   disabled?: boolean;
 }
 
-export function ModelParameterPanel({ params, onChange, disabled }: ModelParameterPanelProps) {
+export function ModelParameterPanel({
+  params,
+  onChange,
+  parameterRanges,
+  onParameterRangesChange,
+  disabled,
+}: ModelParameterPanelProps) {
   const { currentModel } = useModel();
 
   // Get model-specific UI components
@@ -35,6 +45,7 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
   const hasCellTypes = !!CellTypesTab;
   const hasCellEvents = !!CellEventsTab;
   const hasSimulation = !!SimulationTab;
+  const hasParameterRanges = !!parameterRanges && !!onParameterRangesChange;
 
   return (
     <div className="flex flex-col">
@@ -46,12 +57,13 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
       )}
 
       <Tabs defaultValue="parameters" className="flex flex-col">
-        <TabsList className="w-max justify-start shrink-0 h-9">
+        <TabsList className="h-auto min-h-9 w-full flex-wrap justify-start shrink-0">
           <TabsTrigger value="parameters" className="text-xs">Parameters</TabsTrigger>
           {hasConstants && <TabsTrigger value="constants" className="text-xs">Constants</TabsTrigger>}
           {hasCellTypes && <TabsTrigger value="celltypes" className="text-xs">Cell Types</TabsTrigger>}
           {hasCellEvents && <TabsTrigger value="cellevents" className="text-xs">Events</TabsTrigger>}
           {hasSimulation && <TabsTrigger value="simulation" className="text-xs">Simulation</TabsTrigger>}
+          {hasParameterRanges && <TabsTrigger value="ranges" className="text-xs">Parameter Ranges</TabsTrigger>}
         </TabsList>
 
         <TabsContent value="parameters" className="mt-0">
@@ -94,6 +106,19 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
           <TabsContent value="simulation" className="mt-0">
             <div className="p-4 space-y-3">
               <SimulationTab params={params} onChange={onChange} disabled={disabled} />
+            </div>
+          </TabsContent>
+        )}
+
+        {hasParameterRanges && (
+          <TabsContent value="ranges" className="mt-0">
+            <div className="p-4">
+              <ParameterRangeList
+                ranges={parameterRanges}
+                onChange={onParameterRangesChange}
+                baseParams={params}
+                disabled={disabled}
+              />
             </div>
           </TabsContent>
         )}

--- a/src/components/params/ModelParameterPanel.tsx
+++ b/src/components/params/ModelParameterPanel.tsx
@@ -46,7 +46,7 @@ export function ModelParameterPanel({ params, onChange, disabled }: ModelParamet
       )}
 
       <Tabs defaultValue="parameters" className="flex flex-col">
-        <TabsList className="w-full justify-start shrink-0 h-9 overflow-x-auto">
+        <TabsList className="w-max justify-start shrink-0 h-9">
           <TabsTrigger value="parameters" className="text-xs">Parameters</TabsTrigger>
           {hasConstants && <TabsTrigger value="constants" className="text-xs">Constants</TabsTrigger>}
           {hasCellTypes && <TabsTrigger value="celltypes" className="text-xs">Cell Types</TabsTrigger>}

--- a/src/components/params/ParameterConfigView.test.tsx
+++ b/src/components/params/ParameterConfigView.test.tsx
@@ -65,25 +65,14 @@ describe('ParameterConfigView', () => {
     expect(cellTypesScroll.className).not.toContain('max-h');
   });
 
-  it('toggles extended inline sizing without opening the modal', () => {
+  it('uses the expanded inline workspace sizing without a separate extend control', () => {
     renderParameterConfig();
 
     const workspace = screen.getByTestId('parameter-workspace-scroll');
-    const extendButton = screen.getByRole('button', { name: 'Extend' });
 
-    expect(extendButton).toHaveAttribute('aria-expanded', 'false');
-    expect(workspace.className).toContain('h-[min(560px,calc(100vh-280px))]');
-
-    fireEvent.click(extendButton);
-
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Collapse' })).toHaveAttribute('aria-expanded', 'true');
     expect(workspace.className).toContain('h-[min(78vh,900px)]');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
-
-    expect(screen.getByRole('button', { name: 'Extend' })).toHaveAttribute('aria-expanded', 'false');
-    expect(workspace.className).toContain('h-[min(560px,calc(100vh-280px))]');
+    expect(screen.queryByRole('button', { name: 'Extend' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Collapse' })).not.toBeInTheDocument();
   });
 
   it('opens a maximized modal that renders the same editor controls', () => {

--- a/src/components/params/ParameterConfigView.test.tsx
+++ b/src/components/params/ParameterConfigView.test.tsx
@@ -75,19 +75,21 @@ describe('ParameterConfigView', () => {
     expect(screen.queryByRole('button', { name: 'Collapse' })).not.toBeInTheDocument();
   });
 
-  it('places parameter ranges in the model parameter tab row', () => {
+  it('places batch setup in the model parameter tab row', () => {
     renderParameterConfig();
 
-    const rangesTab = screen.getByRole('tab', { name: 'Parameter Ranges' });
-    expect(rangesTab).toBeInTheDocument();
+    const batchTab = screen.getByRole('tab', { name: 'Batch Setup' });
+    expect(batchTab).toBeInTheDocument();
 
-    fireEvent.pointerDown(rangesTab);
-    fireEvent.mouseDown(rangesTab);
-    fireEvent.click(rangesTab);
+    fireEvent.pointerDown(batchTab);
+    fireEvent.mouseDown(batchTab);
+    fireEvent.click(batchTab);
 
     const modelFrame = screen.getByTestId('model-parameter-panel-frame');
     expect(within(modelFrame).getByText('No parameter ranges defined. Add parameters to sweep.')).toBeInTheDocument();
     expect(within(modelFrame).getByRole('combobox', { name: 'Add parameter range' })).toBeInTheDocument();
+    expect(within(modelFrame).getByText('Batch Sampling')).toBeInTheDocument();
+    expect(within(modelFrame).getByLabelText('Seeds per configuration')).toBeInTheDocument();
   });
 
   it('opens a maximized modal that renders the same editor controls', () => {
@@ -99,7 +101,11 @@ describe('ParameterConfigView', () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByTestId('parameter-workspace-modal-scroll')).toHaveClass('overflow-y-auto');
     expect(within(dialog).getByRole('button', { name: 'Load' })).toBeInTheDocument();
-    expect(within(dialog).getByRole('tab', { name: 'Parameter Ranges' })).toBeInTheDocument();
+    const batchTab = within(dialog).getByRole('tab', { name: 'Batch Setup' });
+    expect(batchTab).toBeInTheDocument();
+    fireEvent.pointerDown(batchTab);
+    fireEvent.mouseDown(batchTab);
+    fireEvent.click(batchTab);
     expect(within(dialog).getByText('Batch Sampling')).toBeInTheDocument();
   });
 });

--- a/src/components/params/ParameterConfigView.test.tsx
+++ b/src/components/params/ParameterConfigView.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { cloneDeep } from 'lodash-es';
+import { ParameterConfigView } from './ParameterConfigView';
+import { ModelProvider } from '@/contexts/ModelContext';
+import { DEFAULT_TIME_SAMPLES, type SimulationConfig } from '@/core/params';
+import { DEFAULT_EHT_PARAMS } from '@/models/eht/params/defaults';
+import '@/models';
+
+function createConfig(overrides: Partial<SimulationConfig> = {}): SimulationConfig {
+  return {
+    params: cloneDeep(DEFAULT_EHT_PARAMS),
+    parameterRanges: [],
+    timeSamples: { ...DEFAULT_TIME_SAMPLES },
+    seedsPerConfig: 1,
+    ...overrides,
+  };
+}
+
+function renderParameterConfig(config = createConfig()) {
+  const onConfigChange = vi.fn();
+
+  const view = render(
+    <ModelProvider>
+      <ParameterConfigView config={config} onConfigChange={onConfigChange} />
+    </ModelProvider>
+  );
+
+  return { ...view, onConfigChange };
+}
+
+describe('ParameterConfigView', () => {
+  it('routes parameter edits through the shared live config callback', () => {
+    const { onConfigChange } = renderParameterConfig();
+
+    fireEvent.change(screen.getAllByDisplayValue('48')[0], { target: { value: '72' } });
+
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          general: expect.objectContaining({ t_end: 72 }),
+        }),
+        parameterRanges: [],
+        seedsPerConfig: 1,
+      })
+    );
+  });
+
+  it('uses the workspace as the vertical scroll owner while Cell Types keeps horizontal overflow only', () => {
+    renderParameterConfig();
+
+    const workspace = screen.getByTestId('parameter-workspace-scroll');
+    expect(workspace).toHaveClass('overflow-y-auto');
+
+    const cellTypesTab = screen.getByRole('tab', { name: 'Cell Types' });
+    fireEvent.pointerDown(cellTypesTab);
+    fireEvent.mouseDown(cellTypesTab);
+    fireEvent.click(cellTypesTab);
+
+    const cellTypesScroll = screen.getByTestId('cell-types-table-scroll');
+    expect(cellTypesScroll).toHaveClass('overflow-x-auto');
+    expect(cellTypesScroll).not.toHaveClass('overflow-y-auto');
+    expect(cellTypesScroll.className).not.toContain('max-h');
+  });
+
+  it('toggles extended inline sizing without opening the modal', () => {
+    renderParameterConfig();
+
+    const workspace = screen.getByTestId('parameter-workspace-scroll');
+    const extendButton = screen.getByRole('button', { name: 'Extend' });
+
+    expect(extendButton).toHaveAttribute('aria-expanded', 'false');
+    expect(workspace.className).toContain('h-[min(560px,calc(100vh-280px))]');
+
+    fireEvent.click(extendButton);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Collapse' })).toHaveAttribute('aria-expanded', 'true');
+    expect(workspace.className).toContain('h-[min(78vh,900px)]');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
+
+    expect(screen.getByRole('button', { name: 'Extend' })).toHaveAttribute('aria-expanded', 'false');
+    expect(workspace.className).toContain('h-[min(560px,calc(100vh-280px))]');
+  });
+
+  it('opens a maximized modal that renders the same editor controls', () => {
+    renderParameterConfig();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId('parameter-workspace-modal-scroll')).toHaveClass('overflow-y-auto');
+    expect(within(dialog).getByRole('button', { name: 'Load' })).toBeInTheDocument();
+    expect(within(dialog).getByText('Parameter Ranges')).toBeInTheDocument();
+    expect(within(dialog).getByText('Batch Sampling')).toBeInTheDocument();
+  });
+});

--- a/src/components/params/ParameterConfigView.test.tsx
+++ b/src/components/params/ParameterConfigView.test.tsx
@@ -75,6 +75,21 @@ describe('ParameterConfigView', () => {
     expect(screen.queryByRole('button', { name: 'Collapse' })).not.toBeInTheDocument();
   });
 
+  it('places parameter ranges in the model parameter tab row', () => {
+    renderParameterConfig();
+
+    const rangesTab = screen.getByRole('tab', { name: 'Parameter Ranges' });
+    expect(rangesTab).toBeInTheDocument();
+
+    fireEvent.pointerDown(rangesTab);
+    fireEvent.mouseDown(rangesTab);
+    fireEvent.click(rangesTab);
+
+    const modelFrame = screen.getByTestId('model-parameter-panel-frame');
+    expect(within(modelFrame).getByText('No parameter ranges defined. Add parameters to sweep.')).toBeInTheDocument();
+    expect(within(modelFrame).getByRole('combobox', { name: 'Add parameter range' })).toBeInTheDocument();
+  });
+
   it('opens a maximized modal that renders the same editor controls', () => {
     renderParameterConfig();
 
@@ -84,7 +99,7 @@ describe('ParameterConfigView', () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByTestId('parameter-workspace-modal-scroll')).toHaveClass('overflow-y-auto');
     expect(within(dialog).getByRole('button', { name: 'Load' })).toBeInTheDocument();
-    expect(within(dialog).getByText('Parameter Ranges')).toBeInTheDocument();
+    expect(within(dialog).getByRole('tab', { name: 'Parameter Ranges' })).toBeInTheDocument();
     expect(within(dialog).getByText('Batch Sampling')).toBeInTheDocument();
   });
 });

--- a/src/components/params/ParameterConfigView.tsx
+++ b/src/components/params/ParameterConfigView.tsx
@@ -3,7 +3,7 @@
  * Handles unified load/save to TOML so all values stay together.
  */
 import { useRef, useState } from 'react';
-import { ChevronsDownUp, ChevronsUpDown, Download, FileSpreadsheet, Link2, Maximize2, Upload } from 'lucide-react';
+import { Download, FileSpreadsheet, Link2, Maximize2, Upload } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
 import { Separator } from '../ui/separator';
 import { Button } from '../ui/button';
@@ -232,7 +232,6 @@ export function ParameterConfigView({ config, onConfigChange, disabled }: Parame
   const xlsxInputRef = useRef<HTMLInputElement>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
-  const [isExtended, setIsExtended] = useState(false);
   const [isMaximized, setIsMaximized] = useState(false);
   const presetOptions = PARAM_PRESETS;
 
@@ -368,26 +367,9 @@ export function ParameterConfigView({ config, onConfigChange, disabled }: Parame
       <CardContent className="p-0">
         <div
           data-testid="parameter-workspace-scroll"
-          className={`overflow-y-auto overflow-x-hidden px-6 pb-4 pt-0 ${isExtended ? 'h-[min(78vh,900px)] min-h-[520px]' : 'h-[min(560px,calc(100vh-280px))] min-h-[320px]'}`}
+          className="h-[min(78vh,900px)] min-h-[520px] overflow-y-auto overflow-x-hidden px-6 pb-4 pt-0"
         >
           {!isMaximized && body}
-        </div>
-
-        <div className="border-t px-6 py-3">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setIsExtended((value) => !value)}
-            className="h-8 w-full gap-1.5 text-xs"
-            aria-expanded={isExtended}
-          >
-            {isExtended ? (
-              <ChevronsDownUp className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronsUpDown className="h-3.5 w-3.5" />
-            )}
-            {isExtended ? 'Collapse' : 'Extend'}
-          </Button>
         </div>
       </CardContent>
 

--- a/src/components/params/ParameterConfigView.tsx
+++ b/src/components/params/ParameterConfigView.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { ModelParameterPanel } from './ModelParameterPanel';
+import { ParameterRangeList } from '../batch/ParameterRangeList';
 import { TimeSampleConfig } from '../batch/TimeSampleConfig';
 import type { SimulationConfig } from '@/core/params';
 import type { BaseSimulationParams } from '@/core/registry';
@@ -183,36 +184,44 @@ function ParameterConfigBody({
         <ModelParameterPanel
           params={config.params}
           onChange={onParamsChange}
-          parameterRanges={config.parameterRanges}
-          onParameterRangesChange={onRangesChange}
+          batchSetupContent={
+            <>
+              <ParameterRangeList
+                ranges={config.parameterRanges}
+                onChange={onRangesChange}
+                baseParams={config.params}
+                disabled={disabled}
+              />
+
+              <Separator />
+
+              <div className="space-y-3">
+                <Label className="text-sm font-medium">Batch Sampling</Label>
+                <TimeSampleConfig
+                  config={config.timeSamples}
+                  onChange={onTimeSamplesChange}
+                  disabled={disabled}
+                />
+                <div className="space-y-1">
+                  <Label htmlFor="seeds" className="text-xs text-muted-foreground">
+                    Seeds per configuration
+                  </Label>
+                  <Input
+                    id="seeds"
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={config.seedsPerConfig}
+                    onChange={(e) => onSeedsChange(e.target.value)}
+                    disabled={disabled}
+                    className="h-8 w-32"
+                  />
+                </div>
+              </div>
+            </>
+          }
           disabled={disabled}
         />
-      </div>
-
-      <Separator />
-
-      <div className="space-y-3">
-        <Label className="text-sm font-medium">Batch Sampling</Label>
-        <TimeSampleConfig
-          config={config.timeSamples}
-          onChange={onTimeSamplesChange}
-          disabled={disabled}
-        />
-        <div className="space-y-1">
-          <Label htmlFor="seeds" className="text-xs text-muted-foreground">
-            Seeds per configuration
-          </Label>
-          <Input
-            id="seeds"
-            type="number"
-            min={1}
-            step={1}
-            value={config.seedsPerConfig}
-            onChange={(e) => onSeedsChange(e.target.value)}
-            disabled={disabled}
-            className="h-8 w-32"
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/components/params/ParameterConfigView.tsx
+++ b/src/components/params/ParameterConfigView.tsx
@@ -3,12 +3,13 @@
  * Handles unified load/save to TOML so all values stay together.
  */
 import { useRef, useState } from 'react';
-import { Upload, Download, FileSpreadsheet, Link2 } from 'lucide-react';
+import { ChevronsDownUp, ChevronsUpDown, Download, FileSpreadsheet, Link2, Maximize2, Upload } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
 import { Separator } from '../ui/separator';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
 import {
   Select,
   SelectContent,
@@ -33,12 +34,206 @@ export interface ParameterConfigViewProps {
   disabled?: boolean;
 }
 
+interface ParameterConfigBodyProps {
+  config: SimulationConfig;
+  disabled?: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  xlsxInputRef: React.RefObject<HTMLInputElement | null>;
+  isImporting: boolean;
+  linkCopied: boolean;
+  presetOptions: typeof PARAM_PRESETS;
+  onLoadConfig: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onImportXLSX: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onSaveConfig: () => void;
+  onCopyShareLink: () => void;
+  onApplyPreset: (key: string) => void;
+  onParamsChange: (params: BaseSimulationParams) => void;
+  onRangesChange: (parameterRanges: SimulationConfig['parameterRanges']) => void;
+  onTimeSamplesChange: (timeSamples: SimulationConfig['timeSamples']) => void;
+  onSeedsChange: (value: string) => void;
+}
+
+function ParameterConfigBody({
+  config,
+  disabled,
+  fileInputRef,
+  xlsxInputRef,
+  isImporting,
+  linkCopied,
+  presetOptions,
+  onLoadConfig,
+  onImportXLSX,
+  onSaveConfig,
+  onCopyShareLink,
+  onApplyPreset,
+  onParamsChange,
+  onRangesChange,
+  onTimeSamplesChange,
+  onSeedsChange,
+}: ParameterConfigBodyProps) {
+  return (
+    <div className="space-y-4">
+      {/* File Operations - compact toolbar */}
+      <div className="flex gap-1.5 items-center flex-wrap">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".toml"
+          onChange={onLoadConfig}
+          className="hidden"
+        />
+        <input
+          ref={xlsxInputRef}
+          type="file"
+          accept=".xlsx,.xls"
+          onChange={onImportXLSX}
+          className="hidden"
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          className="h-7 text-xs gap-1.5"
+        >
+          <Upload className="h-3.5 w-3.5" />
+          Load
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSaveConfig}
+          disabled={disabled}
+          className="h-7 text-xs gap-1.5"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Save
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => xlsxInputRef.current?.click()}
+          disabled={disabled || isImporting}
+          className="h-7 text-xs gap-1.5"
+        >
+          <FileSpreadsheet className="h-3.5 w-3.5" />
+          {isImporting ? 'Importing...' : 'XLSX'}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onCopyShareLink}
+          disabled={disabled}
+          className="h-7 text-xs gap-1.5"
+        >
+          <Link2 className="h-3.5 w-3.5" />
+          {linkCopied ? 'Copied!' : 'Share'}
+        </Button>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">Select preset</Label>
+        <Select onValueChange={onApplyPreset} disabled={disabled}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Choose a preset" />
+          </SelectTrigger>
+          <SelectContent>
+            {(() => {
+              // Group presets by their group path
+              const grouped = new Map<string, typeof presetOptions>();
+              for (const preset of presetOptions) {
+                const group = (preset as { group?: string }).group ?? '';
+                if (!grouped.has(group)) grouped.set(group, []);
+                grouped.get(group)!.push(preset);
+              }
+              const elements: React.ReactNode[] = [];
+              for (const [group, items] of grouped) {
+                if (group === '') {
+                  // Root-level presets without a group header
+                  for (const preset of items) {
+                    elements.push(
+                      <SelectItem key={preset.key} value={preset.key}>
+                        {preset.label}
+                      </SelectItem>
+                    );
+                  }
+                } else {
+                  elements.push(
+                    <SelectGroup key={group}>
+                      <SelectLabel className="text-xs text-muted-foreground">{group}</SelectLabel>
+                      {items.map((preset) => (
+                        <SelectItem key={preset.key} value={preset.key}>
+                          {preset.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  );
+                }
+              }
+              return elements;
+            })()}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Separator />
+
+      <div className="border rounded-md" data-testid="model-parameter-panel-frame">
+        <ModelParameterPanel
+          params={config.params}
+          onChange={onParamsChange}
+          disabled={disabled}
+        />
+      </div>
+
+      <Separator />
+
+      <ParameterRangeList
+        ranges={config.parameterRanges}
+        onChange={onRangesChange}
+        baseParams={config.params}
+        disabled={disabled}
+      />
+
+      <Separator />
+
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">Batch Sampling</Label>
+        <TimeSampleConfig
+          config={config.timeSamples}
+          onChange={onTimeSamplesChange}
+          disabled={disabled}
+        />
+        <div className="space-y-1">
+          <Label htmlFor="seeds" className="text-xs text-muted-foreground">
+            Seeds per configuration
+          </Label>
+          <Input
+            id="seeds"
+            type="number"
+            min={1}
+            step={1}
+            value={config.seedsPerConfig}
+            onChange={(e) => onSeedsChange(e.target.value)}
+            disabled={disabled}
+            className="h-8 w-32"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ParameterConfigView({ config, onConfigChange, disabled }: ParameterConfigViewProps) {
   const { currentModel } = useModel();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const xlsxInputRef = useRef<HTMLInputElement>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [isExtended, setIsExtended] = useState(false);
+  const [isMaximized, setIsMaximized] = useState(false);
   const presetOptions = PARAM_PRESETS;
 
   const applyPreset = (key: string) => {
@@ -135,162 +330,84 @@ export function ParameterConfigView({ config, onConfigChange, disabled }: Parame
     }
   };
 
+  const body = (
+    <ParameterConfigBody
+      config={config}
+      disabled={disabled}
+      fileInputRef={fileInputRef}
+      xlsxInputRef={xlsxInputRef}
+      isImporting={isImporting}
+      linkCopied={linkCopied}
+      presetOptions={presetOptions}
+      onLoadConfig={handleLoadConfig}
+      onImportXLSX={handleImportXLSX}
+      onSaveConfig={handleSaveConfig}
+      onCopyShareLink={handleCopyShareLink}
+      onApplyPreset={applyPreset}
+      onParamsChange={handleParamsChange}
+      onRangesChange={handleRangesChange}
+      onTimeSamplesChange={handleTimeSamplesChange}
+      onSeedsChange={handleSeedsChange}
+    />
+  );
+
   return (
-    <Card className="h-full">
-      <CardHeader className="pb-3">
+    <Card className="h-full overflow-hidden">
+      <CardHeader className="pb-3 flex-row items-center justify-between gap-3 space-y-0">
         <CardTitle className="text-base">Parameters &amp; Ranges</CardTitle>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setIsMaximized(true)}
+          className="h-7 text-xs gap-1.5"
+        >
+          <Maximize2 className="h-3.5 w-3.5" />
+          Maximize
+        </Button>
       </CardHeader>
-      <CardContent className="space-y-4">
-        {/* File Operations - compact toolbar */}
-        <div className="flex gap-1.5 items-center flex-wrap">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".toml"
-            onChange={handleLoadConfig}
-            className="hidden"
-          />
-          <input
-            ref={xlsxInputRef}
-            type="file"
-            accept=".xlsx,.xls"
-            onChange={handleImportXLSX}
-            className="hidden"
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={disabled}
-            className="h-7 text-xs gap-1.5"
-          >
-            <Upload className="h-3.5 w-3.5" />
-            Load
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleSaveConfig}
-            disabled={disabled}
-            className="h-7 text-xs gap-1.5"
-          >
-            <Download className="h-3.5 w-3.5" />
-            Save
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => xlsxInputRef.current?.click()}
-            disabled={disabled || isImporting}
-            className="h-7 text-xs gap-1.5"
-          >
-            <FileSpreadsheet className="h-3.5 w-3.5" />
-            {isImporting ? 'Importing...' : 'XLSX'}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleCopyShareLink}
-            disabled={disabled}
-            className="h-7 text-xs gap-1.5"
-          >
-            <Link2 className="h-3.5 w-3.5" />
-            {linkCopied ? 'Copied!' : 'Share'}
-          </Button>
+      <CardContent className="p-0">
+        <div
+          data-testid="parameter-workspace-scroll"
+          className={`overflow-y-auto overflow-x-hidden px-6 pb-4 pt-0 ${isExtended ? 'h-[min(78vh,900px)] min-h-[520px]' : 'h-[min(560px,calc(100vh-280px))] min-h-[320px]'}`}
+        >
+          {!isMaximized && body}
         </div>
 
-        <Separator />
-
-        <div className="space-y-1">
-          <Label className="text-sm font-medium">Select preset</Label>
-          <Select onValueChange={applyPreset} disabled={disabled}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Choose a preset" />
-            </SelectTrigger>
-            <SelectContent>
-              {(() => {
-                // Group presets by their group path
-                const grouped = new Map<string, typeof presetOptions>();
-                for (const preset of presetOptions) {
-                  const group = (preset as { group?: string }).group ?? '';
-                  if (!grouped.has(group)) grouped.set(group, []);
-                  grouped.get(group)!.push(preset);
-                }
-                const elements: React.ReactNode[] = [];
-                for (const [group, items] of grouped) {
-                  if (group === '') {
-                    // Root-level presets without a group header
-                    for (const preset of items) {
-                      elements.push(
-                        <SelectItem key={preset.key} value={preset.key}>
-                          {preset.label}
-                        </SelectItem>
-                      );
-                    }
-                  } else {
-                    elements.push(
-                      <SelectGroup key={group}>
-                        <SelectLabel className="text-xs text-muted-foreground">{group}</SelectLabel>
-                        {items.map((preset) => (
-                          <SelectItem key={preset.key} value={preset.key}>
-                            {preset.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    );
-                  }
-                }
-                return elements;
-              })()}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <Separator />
-
-        <div className="h-[min(500px,calc(100vh-320px))] min-h-[300px] border rounded-md overflow-hidden relative">
-          <ModelParameterPanel
-            params={config.params}
-            onChange={handleParamsChange}
-            disabled={disabled}
-          />
-        </div>
-
-        <Separator />
-
-        <ParameterRangeList
-          ranges={config.parameterRanges}
-          onChange={handleRangesChange}
-          baseParams={config.params}
-          disabled={disabled}
-        />
-
-        <Separator />
-
-        <div className="space-y-3">
-          <Label className="text-sm font-medium">Batch Sampling</Label>
-          <TimeSampleConfig
-            config={config.timeSamples}
-            onChange={handleTimeSamplesChange}
-            disabled={disabled}
-          />
-          <div className="space-y-1">
-            <Label htmlFor="seeds" className="text-xs text-muted-foreground">
-              Seeds per configuration
-            </Label>
-            <Input
-              id="seeds"
-              type="number"
-              min={1}
-              step={1}
-              value={config.seedsPerConfig}
-              onChange={(e) => handleSeedsChange(e.target.value)}
-              disabled={disabled}
-              className="h-8 w-32"
-            />
-          </div>
+        <div className="border-t px-6 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsExtended((value) => !value)}
+            className="h-8 w-full gap-1.5 text-xs"
+            aria-expanded={isExtended}
+          >
+            {isExtended ? (
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            )}
+            {isExtended ? 'Collapse' : 'Extend'}
+          </Button>
         </div>
       </CardContent>
+
+      <Dialog open={isMaximized} onOpenChange={setIsMaximized}>
+        <DialogContent className="w-[min(1280px,calc(100vw-2rem))] max-w-none max-h-[92vh] gap-0 overflow-hidden p-0">
+          <div className="flex max-h-[92vh] min-h-0 flex-col">
+            <div className="border-b bg-background px-4 py-3 pr-14">
+              <DialogHeader>
+                <DialogTitle>Parameters &amp; Ranges</DialogTitle>
+                <DialogDescription className="sr-only">
+                  Edit parameters, parameter ranges, and batch sampling in a larger workspace.
+                </DialogDescription>
+              </DialogHeader>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-4" data-testid="parameter-workspace-modal-scroll">
+              {body}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/components/params/ParameterConfigView.tsx
+++ b/src/components/params/ParameterConfigView.tsx
@@ -20,7 +20,6 @@ import {
   SelectValue,
 } from '../ui/select';
 import { ModelParameterPanel } from './ModelParameterPanel';
-import { ParameterRangeList } from '../batch/ParameterRangeList';
 import { TimeSampleConfig } from '../batch/TimeSampleConfig';
 import type { SimulationConfig } from '@/core/params';
 import type { BaseSimulationParams } from '@/core/registry';
@@ -184,18 +183,11 @@ function ParameterConfigBody({
         <ModelParameterPanel
           params={config.params}
           onChange={onParamsChange}
+          parameterRanges={config.parameterRanges}
+          onParameterRangesChange={onRangesChange}
           disabled={disabled}
         />
       </div>
-
-      <Separator />
-
-      <ParameterRangeList
-        ranges={config.parameterRanges}
-        onChange={onRangesChange}
-        baseParams={config.params}
-        disabled={disabled}
-      />
 
       <Separator />
 

--- a/src/components/simulation/FrameStatsPanel.test.tsx
+++ b/src/components/simulation/FrameStatsPanel.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FrameStatsPanel } from './FrameStatsPanel';
+
+const snapshot = Array.from({ length: 12 }, (_, index) => ({
+  id: index + 1,
+  typeIndex: index % 2,
+  x: index * 0.25,
+  y: index * 0.5,
+}));
+
+describe('FrameStatsPanel', () => {
+  it('opens inline frame data with a vertical scroll owner', () => {
+    render(<FrameStatsPanel snapshot={snapshot} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Frame Data/ }));
+
+    const table = screen.getByRole('table');
+    expect(table.parentElement).toHaveClass('overflow-auto');
+    expect(table.parentElement).toHaveClass('max-w-full');
+    expect(table.closest('.bg-card')).toHaveClass('min-w-0');
+    expect(table).toHaveClass('min-w-max');
+    expect(table.parentElement?.className).toContain('max-h-[min(520px,calc(100vh-280px))]');
+  });
+
+  it('opens a maximized frame data dialog', () => {
+    render(<FrameStatsPanel snapshot={snapshot} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Frame Data')).toBeInTheDocument();
+    expect(within(dialog).getByText('12 cells, 4 columns')).toBeInTheDocument();
+    expect(within(dialog).getByRole('table').parentElement).toHaveClass('overflow-auto');
+  });
+});

--- a/src/components/simulation/FrameStatsPanel.tsx
+++ b/src/components/simulation/FrameStatsPanel.tsx
@@ -2,7 +2,9 @@
  * Frame statistics panel - displays per-cell data table for current frame with collapsible UI and sorting.
  */
 import { useState, useMemo } from 'react';
-import { ChevronDown, ChevronUp, ArrowUpDown } from 'lucide-react';
+import { ChevronDown, ChevronUp, ArrowUpDown, Maximize2 } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
 
 export interface FrameStatsPanelProps {
   /** Per-cell snapshot data (array of row objects) */
@@ -24,6 +26,7 @@ function formatValue(value: unknown): string {
 
 export function FrameStatsPanel({ snapshot }: FrameStatsPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isMaximized, setIsMaximized] = useState(false);
   const [sortKey, setSortKey] = useState<string>('id');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
@@ -72,76 +75,113 @@ export function FrameStatsPanel({ snapshot }: FrameStatsPanelProps) {
     return null;
   }
 
+  const renderTable = () => (
+    <table className="min-w-max text-xs border-collapse">
+      {/* Table Header */}
+      <thead className="bg-muted/30 sticky top-0 z-20">
+        <tr>
+          {columns.map((col, colIndex) => (
+            <th
+              key={col}
+              className={`px-2 py-1.5 text-left font-medium text-muted-foreground whitespace-nowrap ${
+                colIndex === 0
+                  ? 'sticky left-0 z-30 bg-muted/80 border-r border-border/50'
+                  : ''
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => handleSort(col)}
+                className="flex items-center gap-1 hover:text-foreground transition-colors"
+              >
+                {col}
+                <ArrowUpDown size={8} className="opacity-50" />
+                {getSortIndicator(col)}
+              </button>
+            </th>
+          ))}
+        </tr>
+      </thead>
+
+      {/* Table Body */}
+      <tbody>
+        {sortedRows.map((row, rowIndex) => (
+          <tr
+            key={rowIndex}
+            className="border-t border-border/50 hover:bg-muted/20"
+          >
+            {columns.map((col, colIndex) => (
+              <td
+                key={col}
+                className={`px-2 py-1 font-mono whitespace-nowrap ${
+                  colIndex === 0
+                    ? 'sticky left-0 z-10 bg-card border-r border-border/50'
+                    : ''
+                }`}
+              >
+                {formatValue(row[col])}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
   return (
-    <div className="border rounded-md bg-card">
+    <div className="min-w-0 overflow-hidden rounded-md border bg-card">
       {/* Header / Toggle */}
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between px-3 py-2 text-sm font-medium hover:bg-muted/50 transition-colors"
-      >
-        <span>Frame Data</span>
-        <span className="flex items-center gap-2 text-muted-foreground">
-          <span className="text-xs">{snapshot.length} cells, {columns.length} columns</span>
-          {isOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-        </span>
-      </button>
+      <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex min-w-0 flex-1 items-center justify-between gap-2 text-left text-sm font-medium hover:text-foreground/80 transition-colors"
+          aria-expanded={isOpen}
+        >
+          <span>Frame Data</span>
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <span className="text-xs">{snapshot.length} cells, {columns.length} columns</span>
+            {isOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+          </span>
+        </button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setIsMaximized(true)}
+          className="h-7 shrink-0 gap-1.5 text-xs"
+        >
+          <Maximize2 className="h-3.5 w-3.5" />
+          Maximize
+        </Button>
+      </div>
 
       {/* Content */}
       {isOpen && (
-        <div className="border-t overflow-x-auto max-h-72">
-          <table className="w-full text-xs border-collapse">
-            {/* Table Header */}
-            <thead className="bg-muted/30 sticky top-0 z-20">
-              <tr>
-                {columns.map((col, colIndex) => (
-                  <th
-                    key={col}
-                    className={`px-2 py-1.5 text-left font-medium text-muted-foreground whitespace-nowrap ${
-                      colIndex === 0
-                        ? 'sticky left-0 z-30 bg-muted/80 border-r border-border/50'
-                        : ''
-                    }`}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handleSort(col)}
-                      className="flex items-center gap-1 hover:text-foreground transition-colors"
-                    >
-                      {col}
-                      <ArrowUpDown size={8} className="opacity-50" />
-                      {getSortIndicator(col)}
-                    </button>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-
-            {/* Table Body */}
-            <tbody>
-              {sortedRows.map((row, rowIndex) => (
-                <tr
-                  key={rowIndex}
-                  className="border-t border-border/50 hover:bg-muted/20"
-                >
-                  {columns.map((col, colIndex) => (
-                    <td
-                      key={col}
-                      className={`px-2 py-1 font-mono whitespace-nowrap ${
-                        colIndex === 0
-                          ? 'sticky left-0 z-10 bg-card border-r border-border/50'
-                          : ''
-                      }`}
-                    >
-                      {formatValue(row[col])}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="max-w-full overflow-auto border-t max-h-[min(520px,calc(100vh-280px))]">
+          {renderTable()}
         </div>
       )}
+
+      <Dialog open={isMaximized} onOpenChange={setIsMaximized}>
+        <DialogContent className="w-[min(1280px,calc(100vw-2rem))] max-w-none max-h-[92vh] gap-0 overflow-hidden p-0">
+          <div className="flex max-h-[92vh] min-h-0 flex-col">
+            <div className="border-b bg-background px-4 py-3 pr-14">
+              <DialogHeader>
+                <DialogTitle>Frame Data</DialogTitle>
+                <DialogDescription className="sr-only">
+                  Inspect and sort per-cell data for the current simulation frame.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {snapshot.length} cells, {columns.length} columns
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto p-4">
+              {renderTable()}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/models/eht/ui/CellTypesTab.tsx
+++ b/src/models/eht/ui/CellTypesTab.tsx
@@ -580,7 +580,7 @@ export function EHTCellTypesTab({ params, onChange, disabled }: ModelUITabProps<
   }, [addCellType, copyFromType]);
 
   return (
-    <div className="overflow-x-auto overflow-y-auto max-h-[600px]">
+    <div className="overflow-x-auto" data-testid="cell-types-table-scroll">
       <div className="flex justify-end items-center gap-2 mb-2">
         <span className="text-xs text-muted-foreground">Copy from:</span>
         <Select value={copyFromType || '__new__'} onValueChange={setCopyFromType}>


### PR DESCRIPTION
## Summary
- Moved the parameter editor to a single tabbed workspace with consistent maximize behavior and no separate inline extend control.
- Added a `Batch Setup` tab that groups parameter ranges with batch sampling, keeping batch configuration in one place.
- Tightened frame data layout so wide tables stay contained inside the workspace instead of widening the page.

## Testing
- Added and updated unit coverage for parameter panel tab placement, batch setup rendering, and frame data dialog behavior.
- Ran TypeScript checks, the full Vitest suite, a production build, and local Playwright screenshot validation of the updated UI.